### PR TITLE
Support for building with Nix on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ Based off of the original [Amati Project](https://github.com/glocq/Amati) by [Gr
 and will have more features. 
 This project uses the [pamplejuce](https://github.com/sudara/pamplejuce) template as a starting point.
 
+More details will be added as the project gets developed.
+
 Building
 --------
+
 - To build, make sure that libfaust is installed from [here](https://faust.grame.fr/downloads/), and [CMake](https://cmake.org/download/) is installed.
 
 - Next, populate the sub repositories with ``git submodule update --init --recursive``
@@ -17,5 +20,7 @@ Building
   -   ``cmake ..``
   -   ``cmake --build``
 
+### Nix build
 
-More details will be added as the project gets developed.
+You can build the project using [Nix](https://nixos.org/) on Linux: just perform the above steps from within a Nix shell.
+

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+
+    nativeBuildInputs = with pkgs; [
+      gnumake
+      cmake
+      pkg-config
+    ];
+
+    buildInputs = with pkgs; [
+      xorg.libX11.dev
+      xorg.libXft
+      xorg.libXinerama
+      xorg.libXrandr
+      xorg.libXext
+      xorg.libXcursor
+      alsa-lib
+      faust
+    ];
+
+  }


### PR DESCRIPTION
For [Nix](https://nixos.org/) users on Linux, this spares the need to manually install libfaust and CMake and makes the required external headers explicit.

I wrote `shell.nix` to build the project on my own system, so I thought I might as well offer to contribute it, but I am not suggesting it should necessarily be included.